### PR TITLE
Convert image-based devcontainer to compose; share dev service via gitops symlink

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,8 @@
+include:
+  - services/devcontainer-features-dev.yml
+name: "${STACK_NAME:-${DEV_STACK_NAME:-stack}}"
+networks:
+  stack:
+    name: "${STACK_NAME:-${DEV_STACK_NAME:-stack}}"
+  gateway:
+    external: true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,7 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bookworm",
+    "dockerComposeFile": "compose.yml",
+    "service": "devcontainer-features-dev",
+    "workspaceFolder": "/workspaces/devcontainer_features",
     "customizations": {
         "vscode": {
             "settings": {

--- a/.devcontainer/services
+++ b/.devcontainer/services
@@ -1,0 +1,1 @@
+../../gitops/compose/services


### PR DESCRIPTION
Closes #25. Tracked by compusib/gitops#1.

Converts the image-based devcontainer to the shared compose pattern:
- New `.devcontainer/compose.yml` with `include: services/devcontainer-features-dev.yml` and `stack` + external `gateway` networks named `${STACK_NAME:-${DEV_STACK_NAME:-stack}}`.
- `.devcontainer/services -> ../../gitops/compose/services` (symlink); the dev fragment lives in the shared repo.
- `devcontainer.json`: `image:` -> `dockerComposeFile`/`service`/`workspaceFolder`; `features`, `customizations`, `containerEnv`, `remoteUser`, `updateContentCommand`, and the `/data/workspace` mount are preserved.

Validated host-side with `docker compose config` (workspace mounts the repo root at /workspaces/devcontainer_features) and `devcontainer.json` parses.

Note: the dev service attaches to the external `gateway` network for consistency with the other repos, so bring-up needs that network to exist.