### PR TITLE
feat(claude): add claude devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,14 +9,14 @@
       ]
     },
     "ghcr.io/compusib/devcontainer_features/bashrc:0": {
-      "version": "0.0.7",
-      "resolved": "ghcr.io/compusib/devcontainer_features/bashrc@sha256:946361d21e955f2b1be28117c6a4fdd7bf3e3793e1234972f03723abb3d4998b",
-      "integrity": "sha256:946361d21e955f2b1be28117c6a4fdd7bf3e3793e1234972f03723abb3d4998b"
+      "version": "0.0.8",
+      "resolved": "ghcr.io/compusib/devcontainer_features/bashrc@sha256:a08d8591111117e0355403d7069cbf52bb4452eb54caa7711ba3045a892c726f",
+      "integrity": "sha256:a08d8591111117e0355403d7069cbf52bb4452eb54caa7711ba3045a892c726f"
     },
     "ghcr.io/compusib/devcontainer_features/starship:latest": {
-      "version": "0.0.3",
-      "resolved": "ghcr.io/compusib/devcontainer_features/starship@sha256:a2d51c6416479fa9a2983653f2a9e84f643e47239b7685d75dadca667bca5a52",
-      "integrity": "sha256:a2d51c6416479fa9a2983653f2a9e84f643e47239b7685d75dadca667bca5a52",
+      "version": "0.0.4",
+      "resolved": "ghcr.io/compusib/devcontainer_features/starship@sha256:ef34a7212eaa99baf9fe297fcb62accc586e518193a50af74af6004769d5b65f",
+      "integrity": "sha256:ef34a7212eaa99baf9fe297fcb62accc586e518193a50af74af6004769d5b65f",
       "dependsOn": [
         "ghcr.io/compusib/devcontainer_features/bashrc"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,14 @@
             // "compusibBashRepoRoot": "/workspace/compusib/bash"
         },
         "ghcr.io/compusib/devcontainer_features/argbash:0": {},
-        "ghcr.io/compusib/devcontainer_features/starship:latest": {}
+        "ghcr.io/compusib/devcontainer_features/starship:latest": {},
+        // The 'claude' feature lives at src/claude, outside .devcontainer/, so it cannot be
+        // referenced by local path: the dev-containers spec requires a local Feature's source to
+        // be a sub-folder of .devcontainer/, and a symlink there fails the copy step (the CLI uses
+        // ncp, which won't dereference it). It is consumed via its published GHCR image instead.
+        // Defaults match this environment. Test the source directly from the repo root with:
+        //   devcontainer features test -f claude -i mcr.microsoft.com/devcontainers/base:ubuntu .
+        "ghcr.io/compusib/devcontainer_features/claude:0": {}
     },
     "containerEnv": {
         "GIT_AUTHOR_NAME": "${localEnv:GIT_AUTHOR_NAME}",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
           - hello
           - bashrc
           - argbash
+          - claude
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -41,6 +42,7 @@ jobs:
           - bashrc
           - argbash
           - git-hooks
+          - claude
     steps:
       - uses: actions/checkout@v4
 

--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -1,0 +1,60 @@
+
+# Claude (claude)
+
+Installs the private `compusib.settings-bridge` VS Code extension and links the container's
+`~/.claude` to the host home when it is mounted.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/compusib/devcontainer_features/claude:0": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| installSettingsBridge | Install the compusib.settings-bridge VS Code extension. | boolean | true |
+| settingsBridgeRepoPath | Local working tree of settingsBridgeRepo, if it is already checked out into the container (e.g. bind-mounted for extension development). When it contains a *.vsix at settingsBridgeVsixDir it is used as the source, preferred over cloning. Set to empty to always download. | string | /workspace/compusib/ai |
+| settingsBridgeRepo | Git URL of the repo to clone the settings-bridge .vsix from when no local working tree (settingsBridgeRepoPath) is present. SSH form by default (relies on SSH-agent forwarding); use the https URL if your container has an HTTPS credential helper instead. | string | git@github.com:compusib/ai.git |
+| settingsBridgeRef | Git ref (branch/tag) to fetch when downloading the .vsix. | string | main |
+| settingsBridgeVsixDir | Directory holding the built *.vsix, relative to the repo root. Applies identically to settingsBridgeRepoPath and to a fresh clone of settingsBridgeRepo. | string | vscode/settings-bridge/dist |
+| extensionId | Extension id (publisher.name) used for the already-installed idempotency guard. | string | compusib.settings-bridge |
+| hostHomeMountpoint | Location where the host home directory is mounted into the container. When it contains a .claude directory, the container's ~/.claude is symlinked to it. A leading ~/ is expanded to $HOME at runtime. | string | ~/host-home |
+
+## How it works
+
+The extension cannot be installed via `customizations.vscode.extensions` (that only accepts
+marketplace ids) and it must not be vendored into the feature image. So the feature installs two
+small helper scripts at build time and runs them from `postAttachCommand`, where the container's
+git auth and the `code` CLI are both available:
+
+- **`link-host-claude`** — if `hostHomeMountpoint` contains a `.claude` directory, symlinks
+  `~/.claude` to it. An existing symlink is repointed; a real `~/.claude` directory is left
+  untouched.
+- **`install-settings-bridge`** — installs the `compusib.settings-bridge` extension. The source is
+  always a working tree of the repo; the `.vsix` lives at `<repo-root>/settingsBridgeVsixDir`
+  whether that root is a local checkout or a fresh clone:
+  - **Local working tree present** (`settingsBridgeRepoPath/settingsBridgeVsixDir` contains a
+    `*.vsix`): installs from it with `--force` so in-development edits propagate on each rebuild,
+    and removes any previously downloaded copy from the home cache.
+  - **No local working tree**: skips when the extension is already installed; otherwise performs a
+    shallow, sparse `git clone` of `settingsBridgeRepo` (reusing the container's own GitHub auth —
+    SSH-agent forwarding or an HTTPS credential helper), caches the `*.vsix` under
+    `~/.cache/claude-feature/settings-bridge/`, and installs it.
+
+Nothing extension-specific is baked into the feature image; the `.vsix` is always obtained at
+runtime from the local working tree or git.
+
+### Authentication
+
+When downloading, the feature reuses whatever GitHub auth the container already has. The default
+`settingsBridgeRepo` is the SSH form (`git@github.com:compusib/ai.git`) so SSH-agent forwarding
+works out of the box. If your container authenticates over HTTPS instead, set `settingsBridgeRepo`
+to `https://github.com/compusib/ai.git`.
+
+---
+
+_Note: This file may be auto-regenerated from the [devcontainer-feature.json](https://github.com/compusib/devcontainer_features/blob/main/src/claude/devcontainer-feature.json)._

--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,0 +1,50 @@
+{
+    "id": "claude",
+    "version": "0.1.0",
+    "name": "Claude",
+    "description": "Installs the private compusib.settings-bridge VS Code extension (from a local working tree when available, otherwise cloned from git at runtime) and links the container ~/.claude to the host home when mounted.",
+    "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",
+    "options": {
+        "installSettingsBridge": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install the compusib.settings-bridge VS Code extension."
+        },
+        "settingsBridgeRepoPath": {
+            "type": "string",
+            "default": "/workspace/compusib/ai",
+            "description": "Local working tree of settingsBridgeRepo, if it is already checked out into the container (e.g. bind-mounted for extension development). When it contains a *.vsix at settingsBridgeVsixDir it is used as the source, preferred over cloning. Set to empty to always download."
+        },
+        "settingsBridgeRepo": {
+            "type": "string",
+            "default": "git@github.com:compusib/ai.git",
+            "description": "Git URL of the repo to clone the settings-bridge .vsix from when no local working tree (settingsBridgeRepoPath) is present. SSH form by default (relies on SSH-agent forwarding); use the https URL if your container has an HTTPS credential helper instead."
+        },
+        "settingsBridgeRef": {
+            "type": "string",
+            "default": "main",
+            "description": "Git ref (branch/tag) to fetch when downloading the .vsix."
+        },
+        "settingsBridgeVsixDir": {
+            "type": "string",
+            "default": "vscode/settings-bridge/dist",
+            "description": "Directory holding the built *.vsix, relative to the repo root. Applies identically to settingsBridgeRepoPath and to a fresh clone of settingsBridgeRepo."
+        },
+        "extensionId": {
+            "type": "string",
+            "default": "compusib.settings-bridge",
+            "description": "Extension id (publisher.name) used for the already-installed idempotency guard."
+        },
+        "hostHomeMountpoint": {
+            "type": "string",
+            "default": "~/host-home",
+            "description": "Location where the host home directory is mounted into the container. When it contains a .claude directory, the container's ~/.claude is symlinked to it. A leading ~/ is expanded to $HOME at runtime."
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": []
+        }
+    },
+    "postAttachCommand": "link-host-claude || true; install-settings-bridge || true"
+}

--- a/src/claude/install.sh
+++ b/src/claude/install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+echo "Activating feature 'claude'"
+
+FEATURE_LIB_TARGET_DIR="${FEATURE_LIB_DIR:-"/usr/local/lib/features"}/claude"
+CONFIG_FILE="${FEATURE_LIB_TARGET_DIR}/config.env"
+
+# Feature options (passed as environment variables by the devcontainer CLI).
+INSTALL_SETTINGS_BRIDGE="${INSTALLSETTINGSBRIDGE:-true}"
+SETTINGS_BRIDGE_REPO_PATH="${SETTINGSBRIDGEREPOPATH:-/workspace/compusib/ai}"
+SETTINGS_BRIDGE_REPO="${SETTINGSBRIDGEREPO:-git@github.com:compusib/ai.git}"
+SETTINGS_BRIDGE_REF="${SETTINGSBRIDGEREF:-main}"
+SETTINGS_BRIDGE_VSIX_DIR="${SETTINGSBRIDGEVSIXDIR:-vscode/settings-bridge/dist}"
+EXTENSION_ID="${EXTENSIONID:-compusib.settings-bridge}"
+HOST_HOME_MOUNTPOINT="${HOSTHOMEMOUNTPOINT:-~/host-home}"
+
+# Get the directory where this script is located.
+FEATURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install the runtime helper scripts to /usr/local/bin.
+scripts_to_install=(
+    "install-settings-bridge"
+    "link-host-claude"
+)
+for script in "${scripts_to_install[@]}"; do
+    if [[ -f "${FEATURE_DIR}/scripts/${script}" ]]; then
+        echo "📦 Installing ${script} to /usr/local/bin/"
+        cp "${FEATURE_DIR}/scripts/${script}" /usr/local/bin/
+        chmod +x "/usr/local/bin/${script}"
+    else
+        echo "⚠️  Script ${script} not found in ${FEATURE_DIR}/scripts/"
+    fi
+done
+
+# Persist the resolved options so the runtime (postAttach) helpers can read them.
+# No secrets are stored here, only configuration.
+echo "🔧 Writing feature config to ${CONFIG_FILE}"
+mkdir -p "${FEATURE_LIB_TARGET_DIR}"
+cat > "${CONFIG_FILE}" <<EOF
+INSTALL_SETTINGS_BRIDGE="${INSTALL_SETTINGS_BRIDGE}"
+SETTINGS_BRIDGE_REPO_PATH="${SETTINGS_BRIDGE_REPO_PATH}"
+SETTINGS_BRIDGE_REPO="${SETTINGS_BRIDGE_REPO}"
+SETTINGS_BRIDGE_REF="${SETTINGS_BRIDGE_REF}"
+SETTINGS_BRIDGE_VSIX_DIR="${SETTINGS_BRIDGE_VSIX_DIR}"
+EXTENSION_ID="${EXTENSION_ID}"
+HOST_HOME_MOUNTPOINT="${HOST_HOME_MOUNTPOINT}"
+EOF
+
+echo "✅ claude feature installed successfully!"
+echo "   Helpers 'link-host-claude' and 'install-settings-bridge' run on postAttach."

--- a/src/claude/scripts/install-settings-bridge
+++ b/src/claude/scripts/install-settings-bridge
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Install the compusib.settings-bridge VS Code extension.
+#
+# The source is always a working tree of the settings-bridge repo; the only question is whether
+# one is already on disk or has to be fetched:
+#   1. A local working tree already in the container (e.g. bind-mounted for extension development)
+#      -> install from it and remove any previously downloaded home cache.
+#   2. Otherwise clone the prebuilt .vsix from git (reusing the container's own git auth) into a
+#      home cache and install from there.
+# The *.vsix lives at <repo-root>/$SETTINGS_BRIDGE_VSIX_DIR in both cases.
+#
+# Designed to run from the feature's postAttachCommand. It never fails the attach: any skip
+# condition (extension already installed, no `code` CLI, no source available) exits 0.
+
+set -euo pipefail
+
+CONFIG_FILE="${FEATURE_LIB_DIR:-/usr/local/lib/features}/claude/config.env"
+FORCE=0
+[[ "${1:-}" == "--force" ]] && FORCE=1
+
+# Defaults (overridden by the feature config written at install time).
+INSTALL_SETTINGS_BRIDGE="true"
+SETTINGS_BRIDGE_REPO_PATH="/workspace/compusib/ai"
+SETTINGS_BRIDGE_REPO="git@github.com:compusib/ai.git"
+SETTINGS_BRIDGE_REF="main"
+SETTINGS_BRIDGE_VSIX_DIR="vscode/settings-bridge/dist"
+EXTENSION_ID="compusib.settings-bridge"
+# shellcheck source=/dev/null
+[[ -f "$CONFIG_FILE" ]] && . "$CONFIG_FILE"
+
+CACHE_DIR="$HOME/.cache/claude-feature/settings-bridge"
+
+log() { echo "🔧 [settings-bridge] $*"; }
+
+if [[ "$INSTALL_SETTINGS_BRIDGE" != "true" ]]; then
+    log "installSettingsBridge is disabled, skipping."
+    exit 0
+fi
+
+if ! command -v code >/dev/null 2>&1; then
+    log "the 'code' CLI is not available yet, skipping extension install."
+    exit 0
+fi
+
+# Return the first *.vsix in a directory, or empty if none.
+first_vsix() {
+    local dir="$1"
+    [[ -d "$dir" ]] || return 0
+    local f
+    for f in "$dir"/*.vsix; do
+        [[ -e "$f" ]] || continue
+        printf '%s\n' "$f"
+        return 0
+    done
+}
+
+install_vsix() {
+    local vsix="$1"
+    log "installing ${EXTENSION_ID} from ${vsix}"
+    code --install-extension "$vsix" --force
+    log "✅ installed ${EXTENSION_ID}"
+}
+
+# 1) Prefer a local working tree of the repo if one is already on disk (development workflow).
+local_vsix_dir=""
+if [[ -n "$SETTINGS_BRIDGE_REPO_PATH" ]]; then
+    local_vsix_dir="${SETTINGS_BRIDGE_REPO_PATH%/}/${SETTINGS_BRIDGE_VSIX_DIR##/}"
+fi
+if [[ -n "$local_vsix_dir" ]]; then
+    local_vsix="$(first_vsix "$local_vsix_dir")"
+    if [[ -n "$local_vsix" ]]; then
+        log "local working tree detected at ${SETTINGS_BRIDGE_REPO_PATH}"
+        # The extension now comes from the local tree; drop any stale downloaded copy.
+        if [[ -d "$CACHE_DIR" ]]; then
+            log "removing stale home cache ${CACHE_DIR}"
+            rm -rf "$CACHE_DIR"
+        fi
+        # Always force-install from the local tree so in-development edits propagate.
+        install_vsix "$local_vsix"
+        exit 0
+    fi
+    log "no *.vsix under ${local_vsix_dir}, falling back to clone."
+fi
+
+# 2) Download fallback. Skip the clone if the extension is already installed (unless --force).
+if [[ "$FORCE" -ne 1 ]] && code --list-extensions 2>/dev/null | grep -qix "$EXTENSION_ID"; then
+    log "${EXTENSION_ID} already installed, skipping download."
+    exit 0
+fi
+
+tmp=""
+cleanup() { [[ -n "$tmp" && -d "$tmp" ]] && rm -rf "$tmp"; }
+trap cleanup EXIT
+
+log "fetching ${EXTENSION_ID} from ${SETTINGS_BRIDGE_REPO} (${SETTINGS_BRIDGE_REF})"
+tmp="$(mktemp -d)"
+# Shallow + sparse clone so we only pull the vsix directory, using the container's git auth.
+git clone --depth 1 --branch "$SETTINGS_BRIDGE_REF" --filter=blob:none --sparse \
+    "$SETTINGS_BRIDGE_REPO" "$tmp"
+git -C "$tmp" sparse-checkout set "$SETTINGS_BRIDGE_VSIX_DIR"
+
+downloaded_vsix="$(first_vsix "${tmp%/}/${SETTINGS_BRIDGE_VSIX_DIR##/}")"
+if [[ -z "$downloaded_vsix" ]]; then
+    log "no *.vsix found under ${SETTINGS_BRIDGE_VSIX_DIR} in the repo, nothing to install."
+    exit 0
+fi
+
+mkdir -p "$CACHE_DIR"
+cp "$downloaded_vsix" "$CACHE_DIR/"
+cached_vsix="$(first_vsix "$CACHE_DIR")"
+install_vsix "$cached_vsix"

--- a/src/claude/scripts/link-host-claude
+++ b/src/claude/scripts/link-host-claude
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Link the container's ~/.claude to the host home's .claude when the host home is mounted.
+#
+# Designed to run from the feature's postAttachCommand. Never fails the attach and never
+# clobbers a real ~/.claude directory.
+
+set -euo pipefail
+
+CONFIG_FILE="${FEATURE_LIB_DIR:-/usr/local/lib/features}/claude/config.env"
+
+HOST_HOME_MOUNTPOINT="~/host-home"
+# shellcheck source=/dev/null
+[[ -f "$CONFIG_FILE" ]] && . "$CONFIG_FILE"
+
+log() { echo "🔧 [link-host-claude] $*"; }
+
+# Expand a leading ~/ (or bare ~) to $HOME.
+host_home="$HOST_HOME_MOUNTPOINT"
+case "$host_home" in
+    "~") host_home="$HOME" ;;
+    "~/"*) host_home="$HOME/${host_home#\~/}" ;;
+esac
+
+target="${host_home%/}/.claude"
+link="$HOME/.claude"
+
+if [[ ! -d "$target" ]]; then
+    log "host home not present at ${target}, skipping."
+    exit 0
+fi
+
+if [[ -L "$link" ]]; then
+    # Already a symlink: (re)point it at the target.
+    if [[ "$(readlink "$link")" == "$target" ]]; then
+        log "~/.claude already linked to ${target}."
+        exit 0
+    fi
+    log "repointing existing ~/.claude symlink to ${target}"
+    ln -sfn "$target" "$link"
+elif [[ -e "$link" ]]; then
+    # A real file/directory exists: do not clobber it.
+    log "⚠️  ~/.claude already exists and is not a symlink, leaving it untouched."
+    exit 0
+else
+    log "linking ~/.claude -> ${target}"
+    ln -s "$target" "$link"
+fi
+
+log "✅ ~/.claude -> $(readlink "$link")"

--- a/test/claude/host_home_link.sh
+++ b/test/claude/host_home_link.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Verifies that link-host-claude symlinks ~/.claude to the configured host-home mount when that
+# mount contains a .claude directory, and that it refuses to clobber a real ~/.claude.
+
+set -e
+
+source dev-container-features-test-lib
+
+check "link-host-claude on PATH" bash -c "command -v link-host-claude"
+
+# Simulate the host home mount that the feature was configured with (hostHomeMountpoint).
+check "create fake host home" bash -c "mkdir -p /tmp/fake-host-home/.claude"
+
+# Link is created and points at the mount.
+check "links ~/.claude to host home" bash -c "
+    rm -rf \"\$HOME/.claude\" &&
+    link-host-claude &&
+    test -L \"\$HOME/.claude\" &&
+    test \"\$(readlink \"\$HOME/.claude\")\" = /tmp/fake-host-home/.claude
+"
+
+# Re-running is idempotent.
+check "re-run is idempotent" bash -c "
+    link-host-claude &&
+    test -L \"\$HOME/.claude\" &&
+    test \"\$(readlink \"\$HOME/.claude\")\" = /tmp/fake-host-home/.claude
+"
+
+# A real ~/.claude directory must not be clobbered.
+check "does not clobber a real ~/.claude" bash -c "
+    rm -rf \"\$HOME/.claude\" &&
+    mkdir -p \"\$HOME/.claude\" &&
+    touch \"\$HOME/.claude/keep-me\" &&
+    link-host-claude &&
+    test ! -L \"\$HOME/.claude\" &&
+    test -f \"\$HOME/.claude/keep-me\"
+"
+
+reportResults

--- a/test/claude/scenarios.json
+++ b/test/claude/scenarios.json
@@ -1,0 +1,19 @@
+{
+    "host_home_link": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "claude": {
+                "hostHomeMountpoint": "/tmp/fake-host-home",
+                "installSettingsBridge": false
+            }
+        }
+    },
+    "settings_bridge_disabled": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "claude": {
+                "installSettingsBridge": false
+            }
+        }
+    }
+}

--- a/test/claude/settings_bridge_disabled.sh
+++ b/test/claude/settings_bridge_disabled.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Verifies that install-settings-bridge no-ops cleanly when installSettingsBridge is false.
+
+set -e
+
+source dev-container-features-test-lib
+
+check "install-settings-bridge on PATH" bash -c "command -v install-settings-bridge"
+
+# Disabled via the feature option -> must exit 0 without attempting any install/download.
+check "install-settings-bridge exits 0 when disabled" install-settings-bridge
+
+reportResults

--- a/test/claude/test.sh
+++ b/test/claude/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Default-options test for the 'claude' feature.
+#
+# The real install path needs the container's git auth and a running VS Code server (the `code`
+# CLI), neither of which exists in the features test harness. So this verifies the build-time
+# artifacts (helper scripts on PATH, config written) and that the runtime helpers no-op cleanly
+# when there is no `code` CLI and no host-home mount.
+
+set -e
+
+source dev-container-features-test-lib
+
+check "install-settings-bridge on PATH" bash -c "command -v install-settings-bridge"
+check "link-host-claude on PATH" bash -c "command -v link-host-claude"
+check "config.env written" test -f /usr/local/lib/features/claude/config.env
+
+# With no `code` CLI present, the extension installer must exit 0 (never fail the attach).
+check "install-settings-bridge no-ops without code CLI" bash -c "command -v code >/dev/null 2>&1 || install-settings-bridge"
+
+# With no host-home mount, the linker must skip cleanly and not create ~/.claude.
+check "link-host-claude skips when host home absent" bash -c "link-host-claude && test ! -e \"\$HOME/.claude\""
+
+reportResults


### PR DESCRIPTION
## Summary
Adds a new `claude` dev container Feature that, at container **runtime** (via `postAttachCommand`):

- **`link-host-claude`** — symlinks the container `~/.claude` to the host home (`hostHomeMountpoint`) when that mount has a `.claude` dir. Repoints an existing symlink; **refuses to clobber a real `~/.claude`**.
- **`install-settings-bridge`** — installs the `compusib.settings-bridge` VS Code extension. Prefers a local working tree's `*.vsix` (`settingsBridgeRepoPath`) when present (dev edits propagate via `--force`); otherwise shallow+sparse `git clone`s the vsix at runtime and caches it.

Runtime (not build-time) because `customizations.vscode.extensions` only takes marketplace IDs, and the `code` CLI + user's git auth only exist at runtime. `install.sh` only drops helper scripts + writes `config.env` — **no `.vsix`/secrets baked into the image**.

## Why GHCR, not a local path
The feature lives at `src/claude/`, outside `.devcontainer/`. Per the dev-containers spec, **a local Feature's source must be a sub-folder of `.devcontainer/`** ([distribution spec](https://containers.dev/implementors/features-distribution/)), and the CLI rejects parent-dir references with *"Resolved path must be a child of the `.devcontainer/` folder"* ([vscode-remote-release#11356](https://github.com/microsoft/vscode-remote-release/issues/11356)). A symlink into `.devcontainer/` also fails (the CLI's `ncp` copy won't dereference it). So this repo's own `devcontainer.json` consumes it via the **published GHCR id** `ghcr.io/compusib/devcontainer_features/claude:0`.

> Note: the GHCR reference resolves only after `release.yaml` publishes the feature (post-merge).

## Tests
- Added `claude` to both CI matrices in `test.yaml` (autogenerated + scenarios).
- Scenarios: `host_home_link`, `settings_bridge_disabled`; default test asserts helpers on PATH and no-op without code/host-home.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)