### PR TITLE
ci(github/workflows): publish on push to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: "Release dev container features & Generate Documentation"
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Restores automatic publishing on merge to `main`.

The release workflow had drifted to `on: workflow_dispatch:` only, so features only published when someone manually ran it — yet the `deploy` job still carries the `if: github.ref == 'refs/heads/main'` guard, a leftover from the upstream `feature-starter` template that triggers on push to `main`. This re-adds that `push` trigger.

```yaml
on:
  push:
    branches:
      - main
  workflow_dispatch:
```

## Notes
- The existing `if: github.ref == 'refs/heads/main'` guard keeps publishing scoped to `main`.
- `devcontainers/action` only republishes a feature whose `version` actually changed, so merges that don't bump a version are cheap no-ops.
- `workflow_dispatch` is retained for manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
