### PR TITLE
fix(claude): source ~/.bashrc.d in bootstrap-claude-sync so claude/rc…

### DIFF
--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension (from a local working tree when available, otherwise cloned from git at runtime) and provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",

--- a/src/claude/scripts/bootstrap-claude-sync
+++ b/src/claude/scripts/bootstrap-claude-sync
@@ -18,6 +18,26 @@ BOOTSTRAP_CLAUDE_SYNC="true"
 
 log() { echo "🔧 [bootstrap-claude-sync] $*"; }
 
+# Lifecycle hooks run via `/bin/sh -c` — a non-interactive, non-login shell that
+# never sources ~/.bashrc, so the PATH fragments the bashrc feature writes into
+# ~/.bashrc.d/*.sh (where `claude` and `rcloneops` come from) are not applied.
+# Source those fragments directly: sourcing ~/.bashrc itself is unreliable since
+# the stock file returns early for non-interactive shells before its .bashrc.d
+# loop runs. Tolerant of fragments that assume `set -u` is off or emit noise.
+load_bashrc_path() {
+    local frag
+    [[ -d "$HOME/.bashrc.d" ]] || return 0
+    set +u
+    shopt -s nullglob
+    for frag in "$HOME"/.bashrc.d/*.sh; do
+        # shellcheck source=/dev/null
+        . "$frag" >/dev/null 2>&1 || true
+    done
+    shopt -u nullglob
+    set -u
+}
+load_bashrc_path
+
 # Ensure the compusib marketplace is registered and the required plugins are
 # installed. Idempotent. Needs the `claude` CLI; skips cleanly without it.
 ensure_plugins() {


### PR DESCRIPTION
…loneops resolve

Lifecycle hooks run via `/bin/sh -c`, a non-interactive non-login shell that never sources ~/.bashrc, so the ~/.bashrc.d/*.sh PATH fragments (where `claude` and `rcloneops` come from) were absent and the bootstrap skipped plugin install and data sync. Source those fragments directly before probing PATH; sourcing ~/.bashrc itself is unreliable since the stock file returns early for non-interactive shells before its .bashrc.d loop. Defensive against `set -u` and noisy fragments. Bump claude 0.2.0 -> 0.2.1.