### PR TITLE
fix(claude): put bundled claude on PATH; require rclone >= 1.66

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -14,9 +14,9 @@
       "integrity": "sha256:a08d8591111117e0355403d7069cbf52bb4452eb54caa7711ba3045a892c726f"
     },
     "ghcr.io/compusib/devcontainer_features/claude:0": {
-      "version": "0.2.0",
-      "resolved": "ghcr.io/compusib/devcontainer_features/claude@sha256:247f151b1f62ce35873a42563186c013dcb54c3e7a775526117227af4d396a20",
-      "integrity": "sha256:247f151b1f62ce35873a42563186c013dcb54c3e7a775526117227af4d396a20",
+      "version": "0.2.1",
+      "resolved": "ghcr.io/compusib/devcontainer_features/claude@sha256:f23a2191c26bac5b16aabd4ae91fc8465ca0bb36ad5c9143a197901d8a285d9f",
+      "integrity": "sha256:f23a2191c26bac5b16aabd4ae91fc8465ca0bb36ad5c9143a197901d8a285d9f",
       "dependsOn": [
         "ghcr.io/compusib/devcontainer_features/bashrc:0"
       ]

--- a/src/claude/NOTES.md
+++ b/src/claude/NOTES.md
@@ -2,26 +2,36 @@
 
 This feature relies on a few system packages at runtime:
 
-- **`rclone`** — used to move/sync Claude data.
+- **`rclone`** — used to move/sync Claude data. Needs **>= 1.66** because
+  `rcloneops` drives `rclone bisync` with flags (`--conflict-resolve`,
+  `--resilient`, `--recover`, `--max-lock`) introduced in that release.
 - **`jq`** — used to read/manipulate JSON config.
 - **`gh`** — the GitHub CLI.
 
 At build time the feature checks whether each command is already available:
 
-- If present, it does nothing.
-- If missing, it installs the package via `apt-get` as a fallback and prints a
-  warning recommending you bake it into your devcontainer image instead.
+- `jq` and `gh`: if present it does nothing; if missing it installs the package
+  via `apt-get` as a fallback and prints a warning recommending you bake it into
+  your devcontainer image instead.
+- `rclone`: the version matters, not just presence. Debian's apt build lags far
+  behind (e.g. 1.60), so when `rclone` is missing **or older than 1.66** the
+  feature installs the latest via rclone's official script
+  (`curl https://rclone.org/install.sh | bash`) and warns. An already-recent
+  `rclone` is left untouched.
 
 ### Recommended: install them in your Dockerfile
 
 Installing these in your devcontainer's Dockerfile bakes them into the image so
 they don't get re-installed on every rebuild and the build stays reproducible.
 
-`rclone` and `jq` are in Debian's default repos:
+`jq` is in Debian's default repos. `rclone` must be **>= 1.66**, which the apt
+build is usually too old to satisfy, so install it from rclone's official script
+instead:
 
 ```dockerfile
 RUN apt-get update \
- && apt-get install -y --no-install-recommends rclone jq \
+ && apt-get install -y --no-install-recommends jq curl unzip ca-certificates \
+ && curl -fsSL https://rclone.org/install.sh | bash \
  && rm -rf /var/lib/apt/lists/*
 ```
 
@@ -37,10 +47,6 @@ RUN install -m 0755 -d /etc/apt/keyrings \
  && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
 ```
-
-> The `apt` version of `rclone` can lag behind upstream. If you need the latest
-> release, install it via the official script instead:
-> `RUN curl https://rclone.org/install.sh | bash`
 
 ### Skipping the fallback install
 
@@ -63,7 +69,9 @@ On `postAttachCommand`, the feature runs `bootstrap-claude-sync`, which:
    `pluginMarketplace` (default `git@github.com:compusib/ai.git`) with
    `claude plugin marketplace add`, then installs each plugin in `claudePlugins`
    (default `base-stack@compusib`). Idempotent; skips cleanly if the `claude`
-   CLI is absent.
+   CLI is absent. The feature puts the VS Code "Claude Code" extension's bundled
+   `claude` binary on `PATH` (see [Putting `claude` on `PATH`](#putting-claude-on-path)),
+   so this step normally runs even without a separately-installed CLI.
 2. **Provisions data sync for `~/.claude`** via
    `rcloneops claude-bootstrap --no-dry-run` (establishes the bisync baseline and
    installs `SessionStart`/`SessionEnd` sync hooks). Needs the B2 credentials in
@@ -111,6 +119,24 @@ The `bashrc` feature does **not** clone the bash repo — it expects the repo to
 and points `BASH_LIB_DIR` at the repo's `lib/` (so `rcloneops` can source its
 sync library). Without the mount, `rcloneops` is absent and the sync step is
 skipped.
+
+### Putting `claude` on `PATH`
+
+The VS Code "Claude Code" extension ships a native `claude` binary but does not
+put it on `PATH`, and it installs at *attach* time under a directory whose name
+carries the extension version and CPU arch, e.g.
+`~/.vscode-server/extensions/anthropic.claude-code-<version>-<arch>/resources/native-binary/claude`.
+
+So at build time the feature drops a `~/.bashrc.d/190_claude_path.sh` fragment
+that resolves that binary with a glob (newest version wins) and prepends its
+directory to `PATH` when no `claude` is already reachable. This is what lets
+`bootstrap-claude-sync` find `claude` and install the configured plugins. A
+real, separately-installed `claude` CLI on `PATH` always takes precedence and is
+left untouched.
+
+The fragment lands in `~/.bashrc.d` only when the **`bashrc`** feature created
+that directory (it is a `dependsOn`); otherwise the same setup is appended to
+`~/.bashrc`.
 
 ### Required tools
 

--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -30,26 +30,36 @@ Installs the private compusib.settings-bridge VS Code extension (from a local wo
 
 This feature relies on a few system packages at runtime:
 
-- **`rclone`** — used to move/sync Claude data.
+- **`rclone`** — used to move/sync Claude data. Needs **>= 1.66** because
+  `rcloneops` drives `rclone bisync` with flags (`--conflict-resolve`,
+  `--resilient`, `--recover`, `--max-lock`) introduced in that release.
 - **`jq`** — used to read/manipulate JSON config.
 - **`gh`** — the GitHub CLI.
 
 At build time the feature checks whether each command is already available:
 
-- If present, it does nothing.
-- If missing, it installs the package via `apt-get` as a fallback and prints a
-  warning recommending you bake it into your devcontainer image instead.
+- `jq` and `gh`: if present it does nothing; if missing it installs the package
+  via `apt-get` as a fallback and prints a warning recommending you bake it into
+  your devcontainer image instead.
+- `rclone`: the version matters, not just presence. Debian's apt build lags far
+  behind (e.g. 1.60), so when `rclone` is missing **or older than 1.66** the
+  feature installs the latest via rclone's official script
+  (`curl https://rclone.org/install.sh | bash`) and warns. An already-recent
+  `rclone` is left untouched.
 
 ### Recommended: install them in your Dockerfile
 
 Installing these in your devcontainer's Dockerfile bakes them into the image so
 they don't get re-installed on every rebuild and the build stays reproducible.
 
-`rclone` and `jq` are in Debian's default repos:
+`jq` is in Debian's default repos. `rclone` must be **>= 1.66**, which the apt
+build is usually too old to satisfy, so install it from rclone's official script
+instead:
 
 ```dockerfile
 RUN apt-get update \
- && apt-get install -y --no-install-recommends rclone jq \
+ && apt-get install -y --no-install-recommends jq curl unzip ca-certificates \
+ && curl -fsSL https://rclone.org/install.sh | bash \
  && rm -rf /var/lib/apt/lists/*
 ```
 
@@ -65,10 +75,6 @@ RUN install -m 0755 -d /etc/apt/keyrings \
  && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
 ```
-
-> The `apt` version of `rclone` can lag behind upstream. If you need the latest
-> release, install it via the official script instead:
-> `RUN curl https://rclone.org/install.sh | bash`
 
 ### Skipping the fallback install
 
@@ -91,7 +97,9 @@ On `postAttachCommand`, the feature runs `bootstrap-claude-sync`, which:
    `pluginMarketplace` (default `git@github.com:compusib/ai.git`) with
    `claude plugin marketplace add`, then installs each plugin in `claudePlugins`
    (default `base-stack@compusib`). Idempotent; skips cleanly if the `claude`
-   CLI is absent.
+   CLI is absent. The feature puts the VS Code "Claude Code" extension's bundled
+   `claude` binary on `PATH` (see [Putting `claude` on `PATH`](#putting-claude-on-path)),
+   so this step normally runs even without a separately-installed CLI.
 2. **Provisions data sync for `~/.claude`** via
    `rcloneops claude-bootstrap --no-dry-run` (establishes the bisync baseline and
    installs `SessionStart`/`SessionEnd` sync hooks). Needs the B2 credentials in
@@ -139,6 +147,24 @@ The `bashrc` feature does **not** clone the bash repo — it expects the repo to
 and points `BASH_LIB_DIR` at the repo's `lib/` (so `rcloneops` can source its
 sync library). Without the mount, `rcloneops` is absent and the sync step is
 skipped.
+
+### Putting `claude` on `PATH`
+
+The VS Code "Claude Code" extension ships a native `claude` binary but does not
+put it on `PATH`, and it installs at *attach* time under a directory whose name
+carries the extension version and CPU arch, e.g.
+`~/.vscode-server/extensions/anthropic.claude-code-<version>-<arch>/resources/native-binary/claude`.
+
+So at build time the feature drops a `~/.bashrc.d/190_claude_path.sh` fragment
+that resolves that binary with a glob (newest version wins) and prepends its
+directory to `PATH` when no `claude` is already reachable. This is what lets
+`bootstrap-claude-sync` find `claude` and install the configured plugins. A
+real, separately-installed `claude` CLI on `PATH` always takes precedence and is
+left untouched.
+
+The fragment lands in `~/.bashrc.d` only when the **`bashrc`** feature created
+that directory (it is a `dependsOn`); otherwise the same setup is appended to
+`~/.bashrc`.
 
 ### Required tools
 

--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension (from a local working tree when available, otherwise cloned from git at runtime) and provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",

--- a/src/claude/install.sh
+++ b/src/claude/install.sh
@@ -106,10 +106,56 @@ ensure_dependency() {
     rm -rf /var/lib/apt/lists/*
 }
 
+# rclone needs special handling: rcloneops drives `rclone bisync` with flags
+# (--conflict-resolve, --resilient, --recover, --max-lock) that only exist in
+# rclone >= 1.66, but Debian's apt build lags far behind (e.g. 1.60). So for
+# rclone we check the *version*, not just presence, and fall back to rclone's
+# official installer (which always fetches the latest) when it is missing or
+# too old. jq and gh just need to be present, so they stay on ensure_dependency.
+RCLONE_MIN_VERSION="1.66.0"
+
+# Installed rclone version (e.g. "1.60.1"), or empty if rclone is absent.
+rclone_installed_version() {
+    command -v rclone >/dev/null 2>&1 || return 0
+    rclone version 2>/dev/null | sed -n '1s/^rclone v//p'
+}
+
+# version_ge A B → succeeds when version A >= version B.
+version_ge() {
+    [[ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -n1)" == "$2" ]]
+}
+
+# Ensure a recent-enough rclone is installed, upgrading via the official script
+# when the present one is missing or older than RCLONE_MIN_VERSION.
+ensure_rclone() {
+    local have; have="$(rclone_installed_version)"
+    if [[ -n "$have" ]] && version_ge "$have" "$RCLONE_MIN_VERSION"; then
+        echo "✅ 'rclone' ${have} present (>= ${RCLONE_MIN_VERSION}), nothing to do."
+        return 0
+    fi
+
+    if [[ -n "$have" ]]; then
+        echo "⚠️  'rclone' ${have} is older than ${RCLONE_MIN_VERSION} that rcloneops' bisync needs — upgrading via the official installer."
+    else
+        echo "⚠️  'rclone' not found — installing the latest via the official installer."
+    fi
+    echo "    👉 Better to bake the latest rclone into your devcontainer's Dockerfile:"
+    echo "         RUN apt-get update && apt-get install -y --no-install-recommends curl unzip ca-certificates \\"
+    echo "          && curl -fsSL https://rclone.org/install.sh | bash"
+    echo ""
+
+    # The official installer unpacks a zip and uses curl, so make sure both exist.
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -y
+        apt-get install -y --no-install-recommends curl unzip ca-certificates
+    fi
+    curl -fsSL https://rclone.org/install.sh | bash
+}
+
 if [[ "${SKIP_INSTALL_SYSTEM_PACKAGES}" == "true" ]]; then
     echo "⏭️  skipInstallSystemPackages=true — skipping rclone/jq/gh dependency check."
 else
-    ensure_dependency "rclone" "rclone"
+    ensure_rclone
     ensure_dependency "jq" "jq"
     # GitHub CLI is not in Debian's default repos — register GitHub's apt repo.
     ensure_dependency "gh" "gh" \
@@ -134,6 +180,26 @@ for script in "${scripts_to_install[@]}"; do
         echo "⚠️  Script ${script} not found in ${FEATURE_DIR}/scripts/"
     fi
 done
+
+# Put the VS Code extension's bundled `claude` binary on PATH via a ~/.bashrc.d
+# fragment. The extension installs at attach time under a version/arch-specific
+# directory, so the fragment resolves the binary dynamically when sourced (see
+# scripts/claude-path.sh). This is what lets bootstrap-claude-sync find `claude`
+# and actually install the configured plugins. Mirror the bashrc.d-vs-.bashrc
+# fallback the other features use.
+CLAUDE_PATH_FRAGMENT="190_claude_path.sh"
+if [[ -f "${FEATURE_DIR}/scripts/claude-path.sh" ]]; then
+    if [[ -d "${_REMOTE_USER_HOME}/.bashrc.d" ]]; then
+        echo "🔧 Installing ${CLAUDE_PATH_FRAGMENT} to ${_REMOTE_USER_HOME}/.bashrc.d/"
+        cp "${FEATURE_DIR}/scripts/claude-path.sh" "${_REMOTE_USER_HOME}/.bashrc.d/${CLAUDE_PATH_FRAGMENT}"
+        chown "${_REMOTE_USER}" "${_REMOTE_USER_HOME}/.bashrc.d/${CLAUDE_PATH_FRAGMENT}"
+    else
+        echo "🔧 ${_REMOTE_USER_HOME}/.bashrc.d not found — appending claude PATH setup to ${_REMOTE_USER_HOME}/.bashrc"
+        cat "${FEATURE_DIR}/scripts/claude-path.sh" >> "${_REMOTE_USER_HOME}/.bashrc"
+    fi
+else
+    echo "⚠️  scripts/claude-path.sh not found in ${FEATURE_DIR}/scripts/ — 'claude' will not be added to PATH."
+fi
 
 # Persist the resolved options so the runtime (postStart/postAttach) helpers can read them.
 # No secrets are stored here, only configuration.

--- a/src/claude/scripts/claude-path.sh
+++ b/src/claude/scripts/claude-path.sh
@@ -1,0 +1,26 @@
+# Put the VS Code "Claude Code" extension's bundled `claude` binary on PATH.
+#
+# Installed into ~/.bashrc.d by the `claude` devcontainer feature.
+#
+# The extension ships a native `claude` binary but does not put it on PATH, and
+# it installs at *attach* time (after the image is built) under a directory whose
+# name carries the extension version and CPU arch, e.g.
+#   ~/.vscode-server/extensions/anthropic.claude-code-<version>-<arch>/resources/native-binary/claude
+# so the location can only be resolved at shell-init time. Resolve it with a glob
+# and pick the highest version. If a `claude` is already reachable (a real CLI
+# install, or this fragment already ran) we leave PATH untouched.
+if ! command -v claude >/dev/null 2>&1; then
+    # `ls` over the glob: no match → empty (stderr discarded); `sort -V` then
+    # picks the newest version (handles 2.1.9 vs 2.1.177 correctly).
+    _claude_bin=$(ls -d "$HOME"/.vscode-server*/extensions/anthropic.claude-code-*/resources/native-binary/claude \
+        "$HOME"/.cursor-server*/extensions/anthropic.claude-code-*/resources/native-binary/claude \
+        2>/dev/null | sort -V | tail -n 1)
+    if [ -n "$_claude_bin" ] && [ -x "$_claude_bin" ]; then
+        _claude_dir=$(dirname "$_claude_bin")
+        case ":$PATH:" in
+            *":$_claude_dir:"*) ;;                 # already present
+            *) PATH="$_claude_dir:$PATH"; export PATH ;;
+        esac
+    fi
+    unset _claude_bin _claude_dir
+fi

--- a/test/claude/test.sh
+++ b/test/claude/test.sh
@@ -20,7 +20,28 @@ check "config.env records claudePlugins default" bash -c "grep -q 'CLAUDE_PLUGIN
 check "install-settings-bridge no-ops without code CLI" bash -c "command -v code >/dev/null 2>&1 || install-settings-bridge"
 
 # With neither `claude` nor `rcloneops` on PATH, the bootstrap helper must no-op
-# and exit 0 (never fail the attach), creating no ~/.claude.
+# and exit 0 (never fail the attach), creating no ~/.claude. (Runs before the
+# fake-binary test below so no `claude` is resolvable yet.)
 check "bootstrap-claude-sync no-ops without claude/rcloneops" bash -c "bootstrap-claude-sync && test ! -e \"\$HOME/.claude\""
+
+# The build step installs the claude PATH fragment (to ~/.bashrc.d when the
+# bashrc feature created it, otherwise appended to ~/.bashrc).
+check "claude PATH setup installed" bash -c '
+    test -f "$HOME/.bashrc.d/190_claude_path.sh" || grep -q "anthropic.claude-code" "$HOME/.bashrc"
+'
+
+# Functional: a bundled VS Code extension binary on the expected path is resolved
+# onto PATH by the fragment (newest version wins, no real CLI needed).
+check "claude-path fragment resolves the bundled extension binary" bash -c '
+    frag="$HOME/.bashrc.d/190_claude_path.sh"
+    [ -f "$frag" ] || { echo "no bashrc.d fragment present; skipping functional check"; exit 0; }
+    fakedir="$HOME/.vscode-server/extensions/anthropic.claude-code-9.9.9-test/resources/native-binary"
+    mkdir -p "$fakedir"
+    printf "#!/bin/sh\necho fake-claude\n" > "$fakedir/claude"
+    chmod +x "$fakedir/claude"
+    ( PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      . "$frag"
+      command -v claude | grep -q "anthropic.claude-code-9.9.9-test/resources/native-binary/claude" )
+'
 
 reportResults


### PR DESCRIPTION
## Summary
Fixes the two `bootstrap-claude-sync` failures seen on `postAttachCommand`:

1. **`claude` CLI not on PATH → plugins never install.** The VS Code "Claude Code" extension ships a `claude` binary under a version/arch-specific `~/.vscode-server/extensions/anthropic.claude-code-*/…` dir that is never added to PATH. New `~/.bashrc.d/190_claude_path.sh` fragment resolves it dynamically (newest version wins) so the plugin/marketplace step runs. A real `claude` CLI on PATH still wins.

2. **rclone too old for `rclone bisync`.** rcloneops uses `--conflict-resolve`, `--resilient`, `--recover`, `--max-lock` (rclone ≥ 1.66); Debian's apt build is 1.60. The feature now version-gates rclone and installs the latest via the official script when missing or too old; a recent rclone is left untouched.

Adds tests for the PATH fragment, updates NOTES/README, bumps the feature `0.2.1 → 0.3.0`.

> Note: the companion `rclone(1) not found` error came from a separate bug in `rcloneops` (argbash `ARG_USE_PROGRAM` arg order) in the `compusib/bash` repo, fixed in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)