### PR TITLE
fix(claude): install plugins race-free via a SessionStart hook

### DIFF
--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -93,13 +93,30 @@ to `true` so the feature does not attempt to install them at build time:
 
 On `postAttachCommand`, the feature runs `bootstrap-claude-sync`, which:
 
-1. **Ensures the plugin marketplace + plugins are installed.** It registers
-   `pluginMarketplace` (default `git@github.com:compusib/ai.git`) with
-   `claude plugin marketplace add`, then installs each plugin in `claudePlugins`
-   (default `base-stack@compusib`). Idempotent; skips cleanly if the `claude`
-   CLI is absent. The feature puts the VS Code "Claude Code" extension's bundled
-   `claude` binary on `PATH` (see [Putting `claude` on `PATH`](#putting-claude-on-path)),
-   so this step normally runs even without a separately-installed CLI.
+1. **Ensures the plugin marketplace + plugins are installed.** The actual install
+   is done by `ensure-claude-plugins`, which registers `pluginMarketplace`
+   (default `git@github.com:compusib/ai.git`) with `claude plugin marketplace add`
+   and installs each plugin in `claudePlugins` (default `base-stack@compusib`).
+   It is idempotent and **marker-gated** (`~/.claude/.plugins-ensured`, keyed on
+   the marketplace + plugin set), so it is cheap to re-run.
+
+   Because the bundled `claude` binary ships with the VS Code "Claude Code"
+   extension — which installs at *attach* time and **races** this command — a
+   single `postAttach` attempt is unreliable. So `bootstrap-claude-sync` both:
+   - calls `ensure-claude-plugins` directly as a **best-effort fast path** (a
+     no-op when `claude` is not yet on `PATH` — no warning), and
+   - installs a Claude **`SessionStart` hook** that runs `ensure-claude-plugins`
+     the first time `claude` actually runs, where `claude` is guaranteed on
+     `PATH`. This is the race-free path and the one that works in headless
+     (non-VS-Code) containers too.
+
+   > Plugins installed by `claude plugin install` take effect on the **next**
+   > session, so the first launch installs them and the second has them active
+   > (unless the fast path already installed them on attach).
+
+   The hook is merged idempotently into `~/.claude/settings.json` alongside the
+   `rcloneops` sync hooks (each matches a different command), preserving every
+   other key.
 2. **Provisions data sync for `~/.claude`** via
    `rcloneops claude-bootstrap --no-dry-run` (establishes the bisync baseline and
    installs `SessionStart`/`SessionEnd` sync hooks). Needs the B2 credentials in
@@ -168,9 +185,12 @@ that directory (it is a `dependsOn`); otherwise the same setup is appended to
 
 ### Required tools
 
-`bootstrap-claude-sync` uses `claude` (for plugins) and `rcloneops` (for sync;
-which itself needs `rclone` and `jq` — see above). Each step is skipped with a
-warning if its tool is not on `PATH`, so the attach never fails.
+`bootstrap-claude-sync` uses `claude` (for the best-effort plugin fast path),
+`jq` (to merge the `SessionStart` plugin hook into `settings.json`), and
+`rcloneops` (for sync; which itself needs `rclone` and `jq` — see above). The
+sync and fast-path steps no-op cleanly when their tool is absent, and the plugin
+hook still makes plugins install on the first real `claude` launch, so the attach
+never fails.
 
 
 ---

--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension (from a local working tree when available, otherwise cloned from git at runtime) and provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",

--- a/src/claude/install.sh
+++ b/src/claude/install.sh
@@ -170,6 +170,7 @@ FEATURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scripts_to_install=(
     "install-settings-bridge"
     "bootstrap-claude-sync"
+    "ensure-claude-plugins"
 )
 for script in "${scripts_to_install[@]}"; do
     if [[ -f "${FEATURE_DIR}/scripts/${script}" ]]; then

--- a/src/claude/scripts/bootstrap-claude-sync
+++ b/src/claude/scripts/bootstrap-claude-sync
@@ -38,28 +38,64 @@ load_bashrc_path() {
 }
 load_bashrc_path
 
-# Ensure the compusib marketplace is registered and the required plugins are
-# installed. Idempotent. Needs the `claude` CLI; skips cleanly without it.
+# Best-effort plugin install on attach. The `claude` CLI ships only with the VS
+# Code extension, which installs at attach time and races this command, so when
+# it is not yet on PATH we do NOT warn — the SessionStart hook installed below
+# guarantees the install the first time `claude` actually runs.
 ensure_plugins() {
-    if ! command -v claude >/dev/null 2>&1; then
-        log "⚠️  'claude' CLI not on PATH; skipping plugin/marketplace install."
-        return 0
-    fi
     if [[ -z "$CLAUDE_PLUGINS" ]]; then
-        log "⚠️  no claudePlugins configured; nothing to install."
+        log "no claudePlugins configured; nothing to install."
+        return 0
+    fi
+    if ! command -v claude >/dev/null 2>&1; then
+        log "ℹ️  'claude' not on PATH yet (VS Code extension still installing?); the SessionStart hook will install plugins on first launch."
+        return 0
+    fi
+    log "claude present — ensuring plugins now (fast path)."
+    ensure-claude-plugins || log "⚠️  ensure-claude-plugins returned non-zero."
+}
+
+# Register a SessionStart hook that runs ensure-claude-plugins, so plugins are
+# installed the first time `claude` runs regardless of when the extension lands.
+# Merges idempotently into ~/.claude/settings.json (matching on the command),
+# preserving every other key — including the rcloneops SessionStart/SessionEnd
+# sync hooks, which match a different command. Detached so it never blocks the
+# session. Needs jq (a feature dependency); skips cleanly without it.
+install_plugin_hook() {
+    [[ -z "$CLAUDE_PLUGINS" ]] && return 0
+    if ! command -v jq >/dev/null 2>&1; then
+        log "⚠️  jq not on PATH; skipping SessionStart plugin hook install."
         return 0
     fi
 
-    log "ensuring marketplace '${PLUGIN_MARKETPLACE}' is registered"
-    claude plugin marketplace add "$PLUGIN_MARKETPLACE" 2>/dev/null \
-        || log "⚠️  could not add marketplace (already added, or no SSH access)."
+    local ensure_path
+    ensure_path="$(command -v ensure-claude-plugins || echo /usr/local/bin/ensure-claude-plugins)"
+    local cmd
+    cmd="nohup \"${ensure_path}\" </dev/null >>\"\$HOME/.claude/plugins.log\" 2>&1 &"
 
-    local plugin
-    for plugin in $CLAUDE_PLUGINS; do
-        log "ensuring plugin '${plugin}' is installed"
-        claude plugin install "$plugin" 2>/dev/null \
-            || log "⚠️  could not install plugin '${plugin}'."
-    done
+    local settings_file="${HOME}/.claude/settings.json"
+    local current="{}"
+    [[ -s "$settings_file" ]] && current="$(cat "$settings_file")"
+
+    local merged
+    merged="$(printf '%s' "$current" | jq \
+        --arg cmd "$cmd" '
+        # A leaf hook entry that runs our ensure-claude-plugins command.
+        def is_plugins(h): ((h.command // "") | contains("ensure-claude-plugins"));
+        # Strip any prior form first (so we never duplicate), prune emptied
+        # groups, then append the desired command exactly once. Other SessionStart
+        # entries (e.g. the rcloneops sync hook) are left untouched.
+        (.hooks = (.hooks // {}))
+        | .hooks.SessionStart = (((.hooks.SessionStart // [])
+            | map(.hooks = ((.hooks // []) | map(select(is_plugins(.) | not))))
+            | map(select((.hooks // []) | length > 0)))
+            + [{"hooks": [{"type": "command", "command": $cmd}]}])
+    ')" || { log "⚠️  failed to merge plugin hook into settings.json (invalid JSON?)."; return 0; }
+
+    mkdir -p "$(dirname "$settings_file")"
+    local tmp; tmp="$(mktemp)"
+    printf '%s\n' "$merged" > "$tmp" && mv "$tmp" "$settings_file"
+    log "installed SessionStart plugin hook in ${settings_file}."
 }
 
 # Provision data sync for ~/.claude via rcloneops. Skipped when disabled or when
@@ -80,6 +116,7 @@ bootstrap_sync() {
 }
 
 ensure_plugins
+install_plugin_hook
 bootstrap_sync
 log "✅ done."
 exit 0

--- a/src/claude/scripts/ensure-claude-plugins
+++ b/src/claude/scripts/ensure-claude-plugins
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Ensure the compusib Claude plugin marketplace is registered and the configured
+# plugins are installed. Idempotent and marker-gated, so it is cheap to call on
+# every Claude session start.
+#
+# The `claude` CLI ships only with the VS Code "Claude Code" extension, which
+# installs at *attach* time — racing the feature's postAttachCommand. The one
+# moment `claude` is guaranteed on PATH is inside a running `claude`, so this
+# script is registered as a SessionStart hook (see bootstrap-claude-sync) in
+# addition to a best-effort call on attach.
+
+set -uo pipefail
+
+CONFIG_FILE="${FEATURE_LIB_DIR:-/usr/local/lib/features}/claude/config.env"
+
+# Defaults; overridden by config.env written at install time.
+PLUGIN_MARKETPLACE="git@github.com:compusib/ai.git"
+CLAUDE_PLUGINS=""
+# shellcheck source=/dev/null
+[[ -f "$CONFIG_FILE" ]] && . "$CONFIG_FILE"
+
+MARKER="${HOME}/.claude/.plugins-ensured"
+
+log() { echo "🔧 [ensure-claude-plugins] $*"; }
+
+# Nothing configured → nothing to do.
+[[ -z "$CLAUDE_PLUGINS" ]] && exit 0
+
+# This script only does useful work where `claude` exists; exit cleanly otherwise
+# so the SessionStart hook and the postAttach fast path both no-op gracefully.
+command -v claude >/dev/null 2>&1 || exit 0
+
+# Marker gate: skip when the marketplace + plugin set is unchanged from the last
+# successful run. Re-runs when the configuration changes.
+desired="${PLUGIN_MARKETPLACE}|${CLAUDE_PLUGINS}"
+if [[ -f "$MARKER" ]] && [[ "$(cat "$MARKER" 2>/dev/null)" == "$desired" ]]; then
+    exit 0
+fi
+
+log "ensuring marketplace '${PLUGIN_MARKETPLACE}' is registered"
+claude plugin marketplace add "$PLUGIN_MARKETPLACE" 2>/dev/null \
+    || log "⚠️  could not add marketplace (already added, or no SSH access)."
+
+failed=0
+for plugin in $CLAUDE_PLUGINS; do
+    log "ensuring plugin '${plugin}' is installed"
+    claude plugin install "$plugin" 2>/dev/null \
+        || { log "⚠️  could not install plugin '${plugin}'."; failed=1; }
+done
+
+# Only record the marker on a clean run, so a transient failure (e.g. missing SSH
+# access) is retried on the next session rather than being suppressed forever.
+if [[ "$failed" -eq 0 ]]; then
+    mkdir -p "$(dirname "$MARKER")"
+    printf '%s' "$desired" > "$MARKER"
+    log "✅ plugins ensured."
+fi
+
+exit 0

--- a/test/claude/test.sh
+++ b/test/claude/test.sh
@@ -13,16 +13,40 @@ source dev-container-features-test-lib
 
 check "install-settings-bridge on PATH" bash -c "command -v install-settings-bridge"
 check "bootstrap-claude-sync on PATH" bash -c "command -v bootstrap-claude-sync"
+check "ensure-claude-plugins on PATH" bash -c "command -v ensure-claude-plugins"
 check "config.env written" test -f /usr/local/lib/features/claude/config.env
 check "config.env records claudePlugins default" bash -c "grep -q 'CLAUDE_PLUGINS=\"base-stack@compusib\"' /usr/local/lib/features/claude/config.env"
 
 # With no `code` CLI present, the extension installer must exit 0 (never fail the attach).
 check "install-settings-bridge no-ops without code CLI" bash -c "command -v code >/dev/null 2>&1 || install-settings-bridge"
 
-# With neither `claude` nor `rcloneops` on PATH, the bootstrap helper must no-op
-# and exit 0 (never fail the attach), creating no ~/.claude. (Runs before the
+# ensure-claude-plugins must no-op (exit 0, write no marker) when `claude` is not
+# reachable — both the SessionStart hook and the postAttach fast path rely on it
+# skipping cleanly until the extension binary lands.
+check "ensure-claude-plugins no-ops without claude" bash -c "ensure-claude-plugins && test ! -e \"\$HOME/.claude/.plugins-ensured\""
+
+# With neither `claude` nor `rcloneops` on PATH, the bootstrap helper must exit 0
+# (never fail the attach). It still registers the SessionStart plugin hook so the
+# first real `claude` launch installs the configured plugins. (Runs before the
 # fake-binary test below so no `claude` is resolvable yet.)
-check "bootstrap-claude-sync no-ops without claude/rcloneops" bash -c "bootstrap-claude-sync && test ! -e \"\$HOME/.claude\""
+check "bootstrap-claude-sync exits 0 without claude/rcloneops" bash -c "bootstrap-claude-sync"
+check "bootstrap-claude-sync installs the SessionStart plugin hook" bash -c '
+    jq -e ".hooks.SessionStart[].hooks[] | select(.command | contains(\"ensure-claude-plugins\"))" "$HOME/.claude/settings.json" >/dev/null
+'
+
+# The hook merge is idempotent (re-running adds no duplicate) and preserves other
+# SessionStart entries — e.g. an rcloneops-style sync hook that matches a
+# different command.
+check "plugin hook merge is idempotent and preserves other hooks" bash -c '
+    settings="$HOME/.claude/settings.json"
+    # Seed an unrelated SessionStart entry (mimics the rcloneops sync hook).
+    tmp=$(mktemp)
+    jq ".hooks.SessionStart += [{\"hooks\":[{\"type\":\"command\",\"command\":\"rcloneops claude --no-dry-run\"}]}]" "$settings" > "$tmp" && mv "$tmp" "$settings"
+    bootstrap-claude-sync
+    plugins_count=$(jq "[.hooks.SessionStart[].hooks[] | select(.command | contains(\"ensure-claude-plugins\"))] | length" "$settings")
+    sync_count=$(jq "[.hooks.SessionStart[].hooks[] | select(.command | contains(\"rcloneops claude --no-dry-run\"))] | length" "$settings")
+    [ "$plugins_count" = "1" ] && [ "$sync_count" = "1" ]
+'
 
 # The build step installs the claude PATH fragment (to ~/.bashrc.d when the
 # bashrc feature created it, otherwise appended to ~/.bashrc).


### PR DESCRIPTION
## Problem

A fresh devcontainer attach logged:

```
🔧 [bootstrap-claude-sync] ⚠️  'claude' CLI not on PATH; skipping plugin/marketplace install.
```

…and the configured `base-stack@compusib` plugin **silently never installed**.

The feature gets `claude` only from the VS Code "Claude Code" extension's bundled binary, which installs at **attach** time — concurrent with this feature's `postAttachCommand`. So `bootstrap-claude-sync`'s single `command -v claude` check races the extension and usually loses on a fresh build, then bails.

**No devcontainer lifecycle hook can guarantee the binary is present:** `onCreate`/`postCreate`/`postStart` all run *before* extension install, and a headless `devcontainer up` never installs it at all. The one moment `claude` is guaranteed on PATH is **inside a running `claude`** — a Claude `SessionStart` hook.

## Change

- **New `ensure-claude-plugins`**: the marketplace-add + plugin-install loop, made standalone and **marker-gated** (`~/.claude/.plugins-ensured`, keyed on the marketplace + plugin set). The marker is written only on a clean run, so a transient failure (e.g. no SSH access) retries next session.
- **`bootstrap-claude-sync`** now:
  1. calls `ensure-claude-plugins` as a **best-effort fast path** and **demotes** the "not on PATH" warning to an info line (the hook covers it); and
  2. installs a Claude **`SessionStart` hook** that runs `ensure-claude-plugins` the first time `claude` actually runs. Merged idempotently into `settings.json` alongside the `rcloneops` `SessionStart`/`SessionEnd` sync hooks (each matches a different command), preserving every other key. Works in headless containers too.
- `install.sh` ships the new script; feature version **0.3.0 → 0.4.0**; README + `test.sh` updated.

> **Caveat (documented):** plugins installed by `claude plugin install` take effect on the **next** session — first launch installs, second has them active (unless the attach fast path already caught it).

## Tests

`devcontainer features test -f claude` **passes**, including 5 new checks: new script on PATH, no-op without `claude`, exits 0 without `claude`/`rcloneops`, installs the SessionStart hook, and the merge is idempotent + preserves other hooks. Verified in the real container that the warning is gone and the hook is installed.

## Depends on

Runtime-depends on compusib/bash#14 (quieter `rcloneops` output). Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)