### PR TITLE
feat(claude): signal editor reload on plugin-config change; 0.8.0

### DIFF
--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension (from a local working tree when available, otherwise cloned from git at runtime) and provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",

--- a/src/claude/scripts/ensure-marketplace-recursively-installed
+++ b/src/claude/scripts/ensure-marketplace-recursively-installed
@@ -95,4 +95,26 @@ done
 
 printf '%s' "$sig" > "$SENTINEL" 2>/dev/null || true
 log "✅ installed: $(installed_plugins | tr '\n' ' ')"
+
+# Editor reload signal. The Claude extension builds its slash-command/skill index
+# at activation — BEFORE this wrapper runs — so freshly installed plugins aren't
+# registered until the extension host restarts. We can't restart it from bash, so
+# we write the LOGICAL plugin-config hash (id/version/scope/enabled — stable across
+# idempotent reinstalls) to a file settings-bridge watches, and ONLY when it
+# changed. That fires the restart exactly once per real change and never loops on a
+# no-op reinstall. We are authoritative here: we hold the matching claude binary and
+# just finished installing. Best-effort; jq is already required by the seed step.
+if command -v jq >/dev/null 2>&1; then
+    hash_file="${HOME}/.claude/.plugin-config-hash"
+    plugins_json="$("$CLAUDE_BIN" plugin list --json 2>/dev/null || true)"
+    if [[ -n "$plugins_json" ]]; then
+        new_hash="$(printf '%s' "$plugins_json" \
+            | jq -cS 'sort_by(.id) | map({id, version, scope, enabled})' 2>/dev/null \
+            | sha256sum | cut -d' ' -f1)"
+        if [[ -n "$new_hash" && "$new_hash" != "$(cat "$hash_file" 2>/dev/null || true)" ]]; then
+            printf '%s\n' "$new_hash" >"$hash_file" 2>/dev/null \
+                && log "plugin-config changed -> ${hash_file} (settings-bridge reloads the extension host)"
+        fi
+    fi
+fi
 exit 0


### PR DESCRIPTION
After installing the plugin closure, the wrapper writes the logical plugin-config hash (`claude plugin list --json` → `id/version/scope/enabled`, sha256) to `~/.claude/.plugin-config-hash`, **only when it changed**. settings-bridge (0.16.0) watches that file and restarts the extension host so freshly installed plugins register their commands without a manual window reload.

Wrapper-authoritative (it holds the session's `claude` binary), idempotent (writes nothing on a no-op reinstall), and the consumer gates on content (a bare touch never restarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)