### PR TITLE
chore(claude): bump feature 0.8.1 -> 0.8.2

### DIFF
--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension (from a local working tree when available, otherwise cloned from git at runtime) and provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",


### PR DESCRIPTION
Republish current source (remote-cli install fix + plugin-config hash) under a fresh version for unambiguous GHCR/lock resolution.