### PR TITLE
fix(auth): default sshJwtVersion to 'latest'

### DIFF
--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -15,7 +15,7 @@ compusib auth toolchain for devcontainers. Implemented slice — m2m-certs: prov
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | compyRepoPath | Path to the compusib/compy checkout. The jinja-template package is installed from `<path>/apps/jinja-template` into the mise-managed Python. | string | /workspace/compusib/compy |
-| sshJwtVersion | Version of `go.ptx.dk/ssh-jwt` to build via mise's Go backend (`go install go.ptx.dk/ssh-jwt/cmd/ssh-jwt@<version>`). | string | v0.1.0 |
+| sshJwtVersion | Version of `go.ptx.dk/ssh-jwt` to build via mise's Go backend (`go install go.ptx.dk/ssh-jwt/cmd/ssh-jwt@<version>`). Accepts a tag (e.g. `v0.0.6`) or `latest` (resolves to the newest published tag). | string | latest |
 | pythonVersion | Fallback Python to declare via mise (e.g. `3.13`) ONLY if no mise Python is already active. Empty (default) never overrides an existing pin. | string | "" |
 | keepGoToolchain | Keep the Go mise tool after building ssh-jwt. Set `false` to run `mise uninstall go` afterward (ssh-jwt keeps working; rebuilding it later needs Go again). | boolean | true |
 

--- a/src/auth/devcontainer-feature.json
+++ b/src/auth/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "auth",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "name": "auth",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/auth/README.md",
     "description": "compusib auth toolchain for devcontainers. Implemented slice — m2m-certs: provisions jinja-template (compy wheel) and ssh-jwt (go.ptx.dk/ssh-jwt) via mise so the shared bash gen-jwt/gen-cert/trust mint machine-to-machine JWT credentials. Browser auth flows are a planned future slice. Requires a preinstalled mise; it does not install mise.",
@@ -12,8 +12,8 @@
         },
         "sshJwtVersion": {
             "type": "string",
-            "default": "v0.1.0",
-            "description": "Version of go.ptx.dk/ssh-jwt to build via mise's Go backend (go install go.ptx.dk/ssh-jwt/cmd/ssh-jwt@<version>)."
+            "default": "latest",
+            "description": "Version of go.ptx.dk/ssh-jwt to build via mise's Go backend (go install go.ptx.dk/ssh-jwt/cmd/ssh-jwt@<version>). Accepts a tag (e.g. 'v0.0.6') or 'latest' (resolves to the newest published tag)."
         },
         "pythonVersion": {
             "type": "string",

--- a/src/auth/install.sh
+++ b/src/auth/install.sh
@@ -16,7 +16,7 @@ CONFIG_FILE="${FEATURE_LIB_TARGET_DIR}/config.env"
 
 # Feature options (uppercased env vars from the devcontainer CLI).
 COMPY_REPO_PATH="${COMPYREPOPATH:-/workspace/compusib/compy}"
-SSH_JWT_VERSION="${SSHJWTVERSION:-v0.1.0}"
+SSH_JWT_VERSION="${SSHJWTVERSION:-latest}"
 PYTHON_VERSION="${PYTHONVERSION:-}"
 KEEP_GO_TOOLCHAIN="${KEEPGOTOOLCHAIN:-true}"
 

--- a/src/auth/scripts/provision-auth
+++ b/src/auth/scripts/provision-auth
@@ -21,7 +21,7 @@ CONFIG_FILE="${FEATURE_LIB_DIR:-/usr/local/lib/features}/auth/config.env"
 [ -r "$CONFIG_FILE" ] && . "$CONFIG_FILE"
 
 COMPY_REPO_PATH="${COMPY_REPO_PATH:-/workspace/compusib/compy}"
-SSH_JWT_VERSION="${SSH_JWT_VERSION:-v0.1.0}"
+SSH_JWT_VERSION="${SSH_JWT_VERSION:-latest}"
 PYTHON_VERSION="${PYTHON_VERSION:-}"
 KEEP_GO_TOOLCHAIN="${KEEP_GO_TOOLCHAIN:-true}"
 


### PR DESCRIPTION
## Problem

`ssh-jwt` was silently missing in containers using the `auth` feature.

`provision-auth` (run at `onCreateCommand`) builds it via:

```
mise use -g go:go.ptx.dk/ssh-jwt/cmd/ssh-jwt@<sshJwtVersion>
```

The default `sshJwtVersion` was **`v0.1.0`** — a tag that **does not exist** upstream. `github.com/ptxmac/ssh-jwt` tops out at **`v0.0.6`**. (The `v0.1.0` looks copied from the feature's own version number — unrelated.)

With a nonexistent version, `proxy.golang.org` returns not-found, Go falls back to `direct` vanity resolution, and `go.ptx.dk` only serves its `go-import` meta tag at the module **root** (404 on the `/cmd/ssh-jwt` subpath). Result:

```
go: go.ptx.dk/ssh-jwt/cmd/ssh-jwt@v0.1.0: unrecognized import path ... ?go-get=1: 404 Not Found
```

`provision-auth` is warn-only (always `exit 0`), so attach succeeded but `ssh-jwt` was never installed.

## Fix

Default `sshJwtVersion` to **`latest`**. Verified that mise's Go backend accepts `latest` and resolves it to the newest published tag (currently `0.0.6`):

```
mise go:go.ptx.dk/ssh-jwt/cmd/ssh-jwt@latest ✓ installed → 0.0.6
```

The option stays overridable to pin a specific tag (e.g. `v0.0.6`).

## Changes
- `devcontainer-feature.json`: default `latest`, clarified description, version `0.1.0` → `0.1.1`
- `install.sh`, `scripts/provision-auth`: default fallback `latest`
- `README.md`: options table updated