### PR TITLE
test(claude): cover override that does not win (present dir, no manifest)

### DIFF
--- a/test/claude/marketplace_override_no_manifest.sh
+++ b/test/claude/marketplace_override_no_manifest.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Scenario: a pluginMarketplaces entry whose local override directory EXISTS but does
+# NOT contain .claude-plugin/marketplace.json -> the override does NOT win; the feature
+# falls back to the ONLINE (git) source.
+#
+# Complements marketplace_online (which covers the absent-directory case): here the
+# directory is present but is not a marketplace checkout, so it must be ignored — the
+# manifest guard, not mere directory existence, decides whether a local source wins.
+
+set -e
+
+source dev-container-features-test-lib
+
+OVERRIDE="/tmp/compusib-override-no-manifest"
+
+check "config.env records the marketplace entry with the no-manifest override path" \
+    grep -q "PLUGIN_MARKETPLACES=\"compusib|git@github.com:compusib/ai.git|$OVERRIDE\"" /usr/local/lib/features/claude/config.env
+
+# Override dir exists but holds no marketplace.json -> the online git source is registered,
+# and the local directory is NOT.
+check "override without a marketplace.json does not win; online git source used" bash -c '
+    o="/tmp/compusib-override-no-manifest"
+    mkdir -p "$o"; rm -rf "$o/.claude-plugin"   # exists, but NOT a marketplace checkout
+    bin="$(mktemp -d)"; export CLAUDE_LOG="$(mktemp)"
+    printf "#!/bin/bash\necho \"claude \$*\" >> \"\$CLAUDE_LOG\"\nexit 0\n" > "$bin/claude"
+    chmod +x "$bin/claude"
+    PATH="$bin:$PATH" ensure-marketplace-recursively-installed >/dev/null 2>&1
+    grep -q "plugin marketplace add git@github.com:compusib/ai.git" "$CLAUDE_LOG" &&
+    ! grep -q "plugin marketplace add $o" "$CLAUDE_LOG" &&
+    grep -q "plugin install base-stack@compusib" "$CLAUDE_LOG"
+'
+
+reportResults

--- a/test/claude/scenarios.json
+++ b/test/claude/scenarios.json
@@ -25,6 +25,15 @@
             }
         }
     },
+    "marketplace_override_no_manifest": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "claude": {
+                "installSettingsBridge": false,
+                "pluginMarketplaces": "compusib|git@github.com:compusib/ai.git|/tmp/compusib-override-no-manifest"
+            }
+        }
+    },
     "marketplace_multi": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {


### PR DESCRIPTION
## What

Adds a `marketplace_override_no_manifest` test scenario: the `pluginMarketplaces` local override directory **exists** but holds no `.claude-plugin/marketplace.json`, so it must be ignored and the online git source used.

## Why

`marketplace_online` already covers the case where the override path is **absent**. This complements it by exercising the **manifest guard itself** — proving that mere directory existence is not enough for a local override to win; it must actually be a marketplace checkout.

## Tests

Scenario asserts the online git source is registered, the local directory is **not**, and the configured plugin still installs. Verified locally with `bash -n`, JSON validation, and a stubbed-`claude` simulation.