### PR TITLE
feat(claude): install claude-notify-emit for native notifications

### DIFF
--- a/src/claude/NOTES.md
+++ b/src/claude/NOTES.md
@@ -33,6 +33,24 @@ On attach (`postAttachCommand`), `bootstrap-claude-sync` establishes the
 `bootstrapClaudeSync: false`). The session-sync hooks themselves ship in the
 `rclone` plugin (a dependency pulled in above), not from this feature.
 
+## Native notifications
+
+The feature installs `claude-notify-emit` on `PATH`. The `notify` plugin (pulled in
+via `base → notify`, like the rclone hooks) registers Claude hooks that call it when
+the AI is **waiting on you** — `AskUserQuestion`, `ExitPlanMode`, a `Notification`
+(permission prompt / 60s idle) — or **finishes** a turn (`Stop`). `claude-notify-emit`
+appends one JSON line to `~/.claude/notify-queue.jsonl` (it writes nothing to stdout,
+so it can't perturb a `PreToolUse` hook).
+
+That queue is drained by the **settings-bridge** `notify-relay` (workspace extension,
+in the container), which forwards each event over VS Code's extension-host command
+channel to the **`notify-host`** UI extension on the user's machine, which shows a
+native OS banner. The command channel is the only transport that works for a **remote**
+devcontainer. `notify-host` is **not** installed by this feature — it must be installed
+host-side once (it is a UI extension; the feature can only provision the container). See
+`compusib/ai/vscode/notify-host/README.md`. Without it, the queue is simply drained and
+discarded — no error.
+
 ## Requirements
 
 - **Mount the compusib bash repo** at `compusibBashRepoRoot` (default

--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "id": "claude",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "name": "Claude",
-    "description": "Installs the private compusib.settings-bridge VS Code extension in place (from a local working tree when available, otherwise a sparse checkout of compusib/ai at the same canonical path — never copied) and provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach.",
+    "description": "Installs the private compusib.settings-bridge VS Code extension in place (from a local working tree when available, otherwise a sparse checkout of compusib/ai at the same canonical path — never copied), provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach, and installs claude-notify-emit so the notify plugin's hooks can raise native OS notifications (relayed by settings-bridge to the host-side notify-host extension) when Claude is waiting on you.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",
     "options": {
         "installSettingsBridge": {

--- a/src/claude/lib/install-scripts.sh
+++ b/src/claude/lib/install-scripts.sh
@@ -14,6 +14,7 @@ install_runtime_scripts() {
         "install-settings-bridge"
         "bootstrap-claude-sync"
         "ensure-marketplace-recursively-installed"
+        "claude-notify-emit"
     )
     local script
     for script in "${scripts_to_install[@]}"; do

--- a/src/claude/scripts/claude-notify-emit
+++ b/src/claude/scripts/claude-notify-emit
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Append one Claude "the AI is waiting / done" event to the notify queue that the
+# settings-bridge `notify-relay` drains and forwards (across the devcontainer
+# boundary, over VS Code's extension-host command channel) to the UI-side
+# `notify-host` extension, which shows a native OS notification on the user's
+# machine.
+#
+# Invoked from a Claude Code hook (see the `notify` plugin's hooks.json):
+#     claude-notify-emit <event-label>
+# where <event-label> is one of: question | plan | done | permission | idle | notification
+#
+# The hook's JSON payload arrives on stdin; we read it best-effort for a richer
+# message (.message) and the project dir (.cwd). This script writes NOTHING to
+# stdout — a PreToolUse hook's stdout can steer the tool call, so we must not leak.
+set -uo pipefail
+
+event="${1:-notification}"
+queue="${HOME}/.claude/notify-queue.jsonl"
+mkdir -p "$(dirname "$queue")" 2>/dev/null || true
+
+# Capture the hook payload from stdin (hooks always pipe JSON; stdin is not a tty).
+payload=""
+[ -t 0 ] || payload="$(cat 2>/dev/null)"
+
+# json_get <key> -> value (empty if no parser or key absent). python3 preferred; jq fallback.
+json_get() {
+    local key="$1"
+    if command -v python3 >/dev/null 2>&1; then
+        printf '%s' "$payload" | python3 -c "import sys,json
+try:
+    print(json.load(sys.stdin).get('$key','') or '')
+except Exception:
+    pass" 2>/dev/null
+    elif command -v jq >/dev/null 2>&1; then
+        printf '%s' "$payload" | jq -r --arg k "$key" '.[$k] // empty' 2>/dev/null
+    fi
+}
+
+cwd="$(json_get cwd)"; [ -n "$cwd" ] || cwd="$PWD"
+where="$(basename "$cwd" 2>/dev/null || printf '%s' '')"
+hookmsg="$(json_get message)"
+
+case "$event" in
+    question)   msg="Claude has a question" ;;
+    plan)       msg="Plan ready for review" ;;
+    done)       msg="Task complete" ;;
+    permission) msg="${hookmsg:-Permission required}" ;;
+    idle)       msg="${hookmsg:-Waiting for your input}" ;;
+    *)          msg="${hookmsg:-Claude needs your attention}" ;;
+esac
+
+# Build the JSON object with a real serializer when available (safe escaping);
+# otherwise a minimal hand-escaped fallback. Output goes ONLY to the queue file.
+if command -v python3 >/dev/null 2>&1; then
+    python3 -c "import json,sys
+print(json.dumps({'title':'Claude Code','message':sys.argv[1],'subtitle':sys.argv[2],'event':sys.argv[3]}))" \
+        "$msg" "$where" "$event" >> "$queue" 2>/dev/null || true
+else
+    esc() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+    printf '{"title":"Claude Code","message":"%s","subtitle":"%s","event":"%s"}\n' \
+        "$(esc "$msg")" "$(esc "$where")" "$event" >> "$queue" 2>/dev/null || true
+fi
+
+exit 0


### PR DESCRIPTION
Adds `claude-notify-emit` to the `claude` feature so the `notify` plugin's hooks can raise native OS notifications when Claude is waiting on you (question, plan approval, permission prompt, idle) or finishes a turn.

## What's in here
- **`claude-notify-emit`** (new script, on PATH) — reads the hook's stdin JSON (best-effort) for a richer message, appends one JSON line to `~/.claude/notify-queue.jsonl`. Writes **nothing to stdout** so it can't perturb a `PreToolUse` hook. Registered in `install-scripts.sh`.
- Feature bumped 0.13.0 → **0.14.0**; NOTES + description updated.

## Companion change
The queue is drained by the **settings-bridge** `notify-relay` and forwarded to the host-side **notify-host** extension — both in `compusib/ai` (PR compusib/ai#9). The `notify` plugin (which declares the hooks calling this script) is also in that PR and is pulled in by default via `base` → `notify`.

## Verification
Proven end-to-end on macOS through the full `claude-notify-emit` → queue → relay → `notify-host` → native banner chain.