### PR TITLE
fix(claude): name the tool in permission notifications

### DIFF
--- a/src/claude/NOTES.md
+++ b/src/claude/NOTES.md
@@ -37,10 +37,12 @@ On attach (`postAttachCommand`), `bootstrap-claude-sync` establishes the
 
 The feature installs `claude-notify-emit` on `PATH`. The `notify` plugin (pulled in
 via `base → notify`, like the rclone hooks) registers Claude hooks that call it when
-the AI is **waiting on you** — `AskUserQuestion`, `ExitPlanMode`, a `Notification`
-(permission prompt / 60s idle) — or **finishes** a turn (`Stop`). `claude-notify-emit`
-appends one JSON line to `~/.claude/notify-queue.jsonl` (it writes nothing to stdout,
-so it can't perturb a `PreToolUse` hook).
+the AI is **waiting on you** — a tool-permission prompt (`PermissionRequest`),
+`AskUserQuestion`, `ExitPlanMode`, 60s idle (`Notification` matcher `idle_prompt`) — or
+**finishes** a turn (`Stop`). `PermissionRequest` is used for permission prompts because
+the `Notification` hook doesn't fire in the VS Code extension (anthropics/claude-code
+#11156). `claude-notify-emit` appends one JSON line to `~/.claude/notify-queue.jsonl`
+(it writes nothing to stdout, so it can't perturb a hook's decision).
 
 That queue is drained by the **settings-bridge** `notify-relay` (workspace extension,
 in the container), which forwards each event over VS Code's extension-host command

--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension in place (from a local working tree when available, otherwise a sparse checkout of compusib/ai at the same canonical path — never copied), provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach, and installs claude-notify-emit so the notify plugin's hooks can raise native OS notifications (relayed by settings-bridge to the host-side notify-host extension) when Claude is waiting on you.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",

--- a/src/claude/scripts/claude-notify-emit
+++ b/src/claude/scripts/claude-notify-emit
@@ -40,12 +40,14 @@ except Exception:
 cwd="$(json_get cwd)"; [ -n "$cwd" ] || cwd="$PWD"
 where="$(basename "$cwd" 2>/dev/null || printf '%s' '')"
 hookmsg="$(json_get message)"
+toolname="$(json_get tool_name)"
 
 case "$event" in
     question)   msg="Claude has a question" ;;
     plan)       msg="Plan ready for review" ;;
     done)       msg="Task complete" ;;
-    permission) msg="${hookmsg:-Permission required}" ;;
+    # PermissionRequest payload carries tool_name (no .message); name the tool.
+    permission) msg="${hookmsg:-Permission needed${toolname:+ for $toolname}}" ;;
     idle)       msg="${hookmsg:-Waiting for your input}" ;;
     *)          msg="${hookmsg:-Claude needs your attention}" ;;
 esac


### PR DESCRIPTION
`claude-notify-emit` now reads `tool_name` from the `PermissionRequest` payload, so a tool-permission notification reads **"Permission needed for <tool>"**.

Pairs with compusib/ai (notify plugin now drives permission prompts off `PermissionRequest` — the `Notification` hook doesn't fire in the VS Code extension, anthropics/claude-code#11156).

feature 0.14.0 → **0.14.1**.