### PR TITLE
fix(claude): per-window notify queue so banners fire from the right window

### DIFF
--- a/src/claude/NOTES.md
+++ b/src/claude/NOTES.md
@@ -41,8 +41,11 @@ the AI is **waiting on you** — a tool-permission prompt (`PermissionRequest`),
 `AskUserQuestion`, `ExitPlanMode`, 60s idle (`Notification` matcher `idle_prompt`) — or
 **finishes** a turn (`Stop`). `PermissionRequest` is used for permission prompts because
 the `Notification` hook doesn't fire in the VS Code extension (anthropics/claude-code
-#11156). `claude-notify-emit` appends one JSON line to `~/.claude/notify-queue.jsonl`
-(it writes nothing to stdout, so it can't perturb a hook's decision).
+#11156). `claude-notify-emit` appends one JSON line to a **per-window** queue
+`~/.claude/notify-queue/<workspace>-<scope>.jsonl` (scope = remote in a container, local
+otherwise), so the settings-bridge relay in each window drains only its own events and
+the banner fires from the window it belongs to — not a random window sharing `~/.claude`.
+It writes nothing to stdout, so it can't perturb a hook's decision.
 
 That queue is drained by the **settings-bridge** `notify-relay` (workspace extension,
 in the container), which forwards each event over VS Code's extension-host command

--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.14.1",
+    "version": "0.15.0",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension in place (from a local working tree when available, otherwise a sparse checkout of compusib/ai at the same canonical path — never copied), provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach, and installs claude-notify-emit so the notify plugin's hooks can raise native OS notifications (relayed by settings-bridge to the host-side notify-host extension) when Claude is waiting on you.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",

--- a/src/claude/scripts/claude-notify-emit
+++ b/src/claude/scripts/claude-notify-emit
@@ -13,11 +13,15 @@
 # The hook's JSON payload arrives on stdin; we read it best-effort for a richer
 # message (.message) and the project dir (.cwd). This script writes NOTHING to
 # stdout — a PreToolUse hook's stdout can steer the tool call, so we must not leak.
+#
+# The queue is PER PROJECT + SCOPE: ~/.claude/notify-queue/<key>-<scope>.jsonl, where
+# <key> is the sanitized project root and <scope> is remote|local. The settings-bridge
+# relay in each window watches only the file for ITS workspace, so a notification fires
+# from the window it belongs to — not whichever window's relay happened to drain a
+# single shared file (which would focus a random/unrelated window).
 set -uo pipefail
 
 event="${1:-notification}"
-queue="${HOME}/.claude/notify-queue.jsonl"
-mkdir -p "$(dirname "$queue")" 2>/dev/null || true
 
 # Capture the hook payload from stdin (hooks always pipe JSON; stdin is not a tty).
 payload=""
@@ -41,6 +45,17 @@ cwd="$(json_get cwd)"; [ -n "$cwd" ] || cwd="$PWD"
 where="$(basename "$cwd" 2>/dev/null || printf '%s' '')"
 hookmsg="$(json_get message)"
 toolname="$(json_get tool_name)"
+
+# Per-project, per-scope queue. The project root is CLAUDE_PROJECT_DIR (the workspace
+# folder Claude was launched in) so the key matches the relay's workspaceFolder; cwd is
+# the fallback. scope=remote inside a container (/.dockerenv), local otherwise — this is
+# what distinguishes the same folder open both locally and in a devcontainer. The
+# sanitize rule MUST match the relay's: replace every non [A-Za-z0-9_-] char with '-'.
+proj="${CLAUDE_PROJECT_DIR:-$cwd}"
+key="$(printf '%s' "$proj" | sed 's#[^A-Za-z0-9_-]#-#g')"
+[ -f /.dockerenv ] && scope="remote" || scope="local"
+queue="${HOME}/.claude/notify-queue/${key}-${scope}.jsonl"
+mkdir -p "$(dirname "$queue")" 2>/dev/null || true
 
 case "$event" in
     question)   msg="Claude has a question" ;;


### PR DESCRIPTION
`claude-notify-emit` now writes to a **per-window** queue `~/.claude/notify-queue/<key>-<scope>.jsonl` (key = sanitized `CLAUDE_PROJECT_DIR`, scope = remote in a container / local otherwise) instead of one shared file. The settings-bridge relay in each window watches only its matching file, so a notification fires from the window it belongs to — fixing notifications that focused random unrelated windows.

Pairs with compusib/ai#13 (the relay computes the same key). feature 0.14.1 → **0.15.0**.