### PR TITLE
docs(claude): point to the host-setup checklist for native notifications

### DIFF
--- a/src/claude/NOTES.md
+++ b/src/claude/NOTES.md
@@ -52,9 +52,14 @@ in the container), which forwards each event over VS Code's extension-host comma
 channel to the **`notify-host`** UI extension on the user's machine, which shows a
 native OS banner. The command channel is the only transport that works for a **remote**
 devcontainer. `notify-host` is **not** installed by this feature — it must be installed
-host-side once (it is a UI extension; the feature can only provision the container). See
-`compusib/ai/vscode/notify-host/README.md`. Without it, the queue is simply drained and
-discarded — no error.
+host-side once (it is a UI extension; the feature can only provision the container).
+Without it the queue is simply drained and discarded (no error), and `settings-bridge`
+shows a one-time, dismissible prompt with the install command.
+
+**Host setup (one-time, per Mac):** install `notify-host`, plus `terminal-notifier` and
+`AltTab` for click-to-focus, and grant the macOS permissions — see the checklist at the
+top of `compusib/ai/vscode/notify-host/README.md`. The extensions nudge you when a piece
+is missing; suppress with `compusib.notify.suppressSetupPrompts`.
 
 ## Requirements
 

--- a/src/claude/devcontainer-feature.json
+++ b/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "name": "Claude",
     "description": "Installs the private compusib.settings-bridge VS Code extension in place (from a local working tree when available, otherwise a sparse checkout of compusib/ai at the same canonical path — never copied), provisions Claude data sync (~/.claude to Backblaze B2 via rcloneops) on attach, and installs claude-notify-emit so the notify plugin's hooks can raise native OS notifications (relayed by settings-bridge to the host-side notify-host extension) when Claude is waiting on you.",
     "documentationURL": "https://github.com/compusib/devcontainer_features/blob/main/src/claude/README.md",


### PR DESCRIPTION
Feature NOTES now points to the consolidated **Host setup (one-time, per Mac)** checklist (notify-host README) and notes the dismissible setup prompts + `compusib.notify.suppressSetupPrompts`. Doc-only; feature 0.15.0 → **0.15.1**.